### PR TITLE
Fix prop VueCodeHighlighterMulti in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There are 2 types of components, namely VueCodeHighlighter and VueCodeHighlighte
 
 | Attribute    |   Type   |    Is Required     | Description                                                                   |
 |:-------------|:--------:|:--------------:|:------------------------------------------------------------------------------|
-| lang      |  String  |       true       | Code languange from Highlighter cheatset, see <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md">Supported languange</a>                                              |
+| code      |  String  |       true       | Code languange from Highlighter cheatset, see <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md">Supported languange</a>                                              |
 | code         |  String  |   true    | Plain code which will be displayed,  please wrap your code using backtick (``)           |
 | title     |  String  | no | Custom title in header |
 | disableCopy     |  Boolean  |     no     | Disable copy button and copy functionality to code        |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There are 2 types of components, namely VueCodeHighlighter and VueCodeHighlighte
 
 | Attribute    |   Type   |    Is Required     | Description                                                                   |
 |:-------------|:--------:|:--------------:|:------------------------------------------------------------------------------|
-| code      |  String  |       true       | Code languange from Highlighter cheatset, see <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md">Supported languange</a>                                              |
+| lang      |  String  |       true       | Code languange from Highlighter cheatset, see <a href="https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md">Supported languange</a>                                              |
 | code         |  String  |   true    | Plain code which will be displayed,  please wrap your code using backtick (``)           |
 | title     |  String  | no | Custom title in header |
 | disableCopy     |  Boolean  |     no     | Disable copy button and copy functionality to code        |
@@ -57,7 +57,7 @@ There are 2 types of components, namely VueCodeHighlighter and VueCodeHighlighte
 
 | Attribute    |   Type   |    Is Required     | Description                                                                   |
 |:-------------|:--------:|:--------------:|:------------------------------------------------------------------------------|
-| lang      |  Array  |       true       | See example below                                         |
+| code      |  Array  |       true       | See example below                                         |
  disableCopy     |  Boolean  |     no     | Disable copy button and copy functionality to code        |
 
 <p>Example for lang props in Multi Code.</p>


### PR DESCRIPTION
Small typo that I noticed regarding the `prop` of the `VueCodeHighlighterMulti` component

Awesome package!